### PR TITLE
更新文档中的 Makefile -- 2672d8e get rid of Position-independent code sections

### DIFF
--- a/doc/xelatex/hurlex-chapt1.tex
+++ b/doc/xelatex/hurlex-chapt1.tex
@@ -113,7 +113,7 @@ CC = gcc
 LD = ld
 ASM = nasm
 
-C_FLAGS = -c -Wall -m32 -ggdb -gstabs+ -nostdinc -fno-builtin -fno-stack-protector -I include
+C_FLAGS = -c -Wall -m32 -ggdb -gstabs+ -nostdinc -fon-pic -fno-builtin -fno-stack-protector -I include
 LD_FLAGS = -T scripts/kernel.ld -m elf_i386 -nostdlib
 ASM_FLAGS = -f elf -g -F stabs
 


### PR DESCRIPTION
高版本GCC编译第十章中的代码无法运行，建议直接在第一章Makefile中修改为
https://github.com/hurley25/hurlex-doc/commit/2672d8e702148270ff2072e01ae732ce52ba34c5
的解决方法。
pdf文档没更新，抱歉没时间折腾xelatex中文输出。